### PR TITLE
feat: bbt_count stats

### DIFF
--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -371,7 +371,7 @@ def register_commands(
             [
                 f"{i+1}. <@{user_data.get('user_id')}>: {user_data.get('count')} 🧋"
                 + (
-                    f" *average rating: {user_data.get('average_rating'):.3f}*"
+                    f" *average given rating: {user_data.get('average_rating'):.3f}*"
                     if user_data.get("average_rating")
                     else ""
                 )

--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -65,7 +65,7 @@ def register_commands(
         rating: float = None,
     ):
         await interaction.response.defer()
-        
+
         if image and not image.content_type.startswith("image/"):
             await interaction.followup.send(
                 "Invalid image type. Please upload an image file.",
@@ -369,7 +369,12 @@ def register_commands(
         )
         embed.description = "\n".join(
             [
-                f"{i+1}. <@{user_data['user_id']}>: {user_data['count']} 🧋"
+                f"{i+1}. <@{user_data.get('user_id')}>: {user_data.get('count')} 🧋"
+                + (
+                    f" *average rating: {user_data.get('average_rating'):.3f}*"
+                    if user_data.get("average_rating")
+                    else ""
+                )
                 for i, user_data in enumerate(leaderboard)
             ]
         )

--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -14,6 +14,7 @@ from .db_functions import (
     get_bbt_entries,
     get_bbt_leaderboard,
     get_bubble_tea_stats,
+    get_latest_bubble_tea_entry,
 )
 from .embeds import (
     bbt_entry_embed,
@@ -404,8 +405,14 @@ def register_commands(
             ),
             group_by_location,
         )
+        latest = get_latest_bubble_tea_entry(interaction.user.id)
         embed = bbt_stats_embed(
-            interaction.user.id, stats, year, group_by_location
+            interaction.user.id,
+            stats,
+            year,
+            group_by_location,
+            latest,
+            interaction.created_at.astimezone().tzinfo,
         )
         await interaction.followup.send(embed=embed)
 

--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -385,6 +385,12 @@ def register_commands(
     @bbt_count.command(
         name="stats", description="Get the stats for a user for a given year"
     )
+    @app_commands.describe(
+        year="Year to get stats for (optional, default to current year)"
+    )
+    @app_commands.describe(
+        group_by_location="Group the stats by location (optional)"
+    )
     async def bbt_count_stats(
         interaction: discord.Interaction,
         year: int = None,

--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -420,7 +420,7 @@ def register_commands(
             ),
         )
 
-        latest = get_latest_bubble_tea_entry(user_id)
+        latest = get_latest_bubble_tea_entry(user_id) if year and year == datetime.datetime.now().year else None
         embed = bbt_stats_embed(
             user_id,
             stats,

--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -385,6 +385,9 @@ def register_commands(
         name="stats", description="Get the stats for a user for a given year"
     )
     @app_commands.describe(
+        user="User to get stats for (optional, default to self)"
+    )
+    @app_commands.describe(
         year="Year to get stats for (optional, default to current year)"
     )
     @app_commands.describe(
@@ -392,12 +395,14 @@ def register_commands(
     )
     async def bbt_count_stats(
         interaction: discord.Interaction,
+        user: discord.User = None,
         year: int = None,
         group_by_location: bool = False,
     ):
         await interaction.response.defer()
+        user_id = user.id if user else interaction.user.id
         stats = get_bubble_tea_stats(
-            interaction.user.id,
+            user_id,
             (
                 datetime.datetime(year=year, month=1, day=1)
                 if year
@@ -405,9 +410,9 @@ def register_commands(
             ),
             group_by_location,
         )
-        latest = get_latest_bubble_tea_entry(interaction.user.id)
+        latest = get_latest_bubble_tea_entry(user_id)
         embed = bbt_stats_embed(
-            interaction.user.id,
+            user_id,
             stats,
             year,
             group_by_location,

--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -13,12 +13,14 @@ from .db_functions import (
     edit_bbt_entry,
     get_bbt_entries,
     get_bbt_leaderboard,
+    get_bubble_tea_stats,
 )
 from .embeds import (
     bbt_entry_embed,
     bbt_list_default_embed,
     bbt_list_grouped_embed,
     user_transfer_embed,
+    bbt_stats_embed,
 )
 from .helpers import bubble_tea_data
 from ..modules import logging, content_moderation
@@ -63,7 +65,7 @@ def register_commands(
         rating: float = None,
     ):
         await interaction.response.defer()
-        
+
         image_review = await content_moderation.review_image(image)
         if image and not image.content_type.startswith("image/"):
             await interaction.followup.send(
@@ -262,6 +264,7 @@ def register_commands(
 
         # Show transfer button choices if transfer_user is specified
         if transfer_user and transfer_user.id != interaction.user.id:
+
             class TransferButtonView(discord.ui.View):
                 def __init__(self):
                     super().__init__()
@@ -376,6 +379,29 @@ def register_commands(
                 f"{i+1}. <@{user_data['user_id']}>: {user_data['count']} 🧋"
                 for i, user_data in enumerate(leaderboard)
             ]
+        )
+        await interaction.followup.send(embed=embed)
+
+    @bbt_count.command(
+        name="stats", description="Get the stats for a user for a given year"
+    )
+    async def bbt_count_stats(
+        interaction: discord.Interaction,
+        year: int = None,
+        group_by_location: bool = False,
+    ):
+        await interaction.response.defer()
+        stats = get_bubble_tea_stats(
+            interaction.user.id,
+            (
+                datetime.datetime(year=year, month=1, day=1)
+                if year
+                else interaction.created_at
+            ),
+            group_by_location,
+        )
+        embed = bbt_stats_embed(
+            interaction.user.id, stats, year, group_by_location
         )
         await interaction.followup.send(embed=embed)
 

--- a/commands/bbt_count/bbt_count.py
+++ b/commands/bbt_count/bbt_count.py
@@ -8,6 +8,7 @@ from commands.bbt_count.consts import BBT_LIST_GROUP_BY_CHOICES
 
 from .db_functions import (
     add_bbt_entry,
+    get_bubble_tea_monthly_counts,
     remove_bbt_entry,
     get_bbt_entry,
     edit_bbt_entry,
@@ -410,12 +411,22 @@ def register_commands(
             ),
             group_by_location,
         )
+        monthly_counts = get_bubble_tea_monthly_counts(
+            user_id,
+            (
+                datetime.datetime(year=year, month=1, day=1)
+                if year
+                else interaction.created_at
+            ),
+        )
+
         latest = get_latest_bubble_tea_entry(user_id)
         embed = bbt_stats_embed(
             user_id,
             stats,
             year,
             group_by_location,
+            monthly_counts,
             latest,
             interaction.created_at.astimezone().tzinfo,
         )

--- a/commands/bbt_count/db_functions.py
+++ b/commands/bbt_count/db_functions.py
@@ -123,6 +123,7 @@ def get_bbt_leaderboard(guild_id: int, date: datetime):
     return results
 
 
+# Gets the bubble tea stats for a user in a given year
 def get_bubble_tea_stats(
     user_id: int, date: datetime, group_by_location=False
 ):
@@ -139,6 +140,23 @@ def get_bubble_tea_stats(
     results = data[1]
     return results
 
+
+# Gets the bubble tea monthly counts for a user
+def get_bubble_tea_monthly_counts(user_id: int, date: datetime):
+    data, c = supabaseClient.rpc(
+        "get_bubble_tea_monthly_counts",
+        {
+            "user_id": user_id,
+            "date": str(date),
+        },
+    ).execute()
+    if c == 0:
+        return []
+    results = data[1]
+    return results
+
+
+# Get the user's latest bubble tea entry
 def get_latest_bubble_tea_entry(user_id: int):
     data, c = (
         supabaseClient.table(TABLE)
@@ -154,4 +172,7 @@ def get_latest_bubble_tea_entry(user_id: int):
     )
     if c == 0:
         return None
-    return data[1][0]
+    try:
+        return data[1][0]
+    except IndexError:
+        return None

--- a/commands/bbt_count/db_functions.py
+++ b/commands/bbt_count/db_functions.py
@@ -120,6 +120,21 @@ def get_bbt_leaderboard(guild_id: int, date: datetime):
     if c == 0:
         return []
     results = data[1]
-    # sort the data
-    results.sort(key=lambda x: x["count"], reverse=True)
+    return results
+
+
+def get_bubble_tea_stats(
+    user_id: int, date: datetime, group_by_location=False
+):
+    data, c = supabaseClient.rpc(
+        "get_bubble_tea_stats",
+        {
+            "user_id": user_id,
+            "date": str(date),
+            "group_by_location": group_by_location,
+        },
+    ).execute()
+    if c == 0:
+        return []
+    results = data[1]
     return results

--- a/commands/bbt_count/db_functions.py
+++ b/commands/bbt_count/db_functions.py
@@ -138,3 +138,20 @@ def get_bubble_tea_stats(
         return []
     results = data[1]
     return results
+
+def get_latest_bubble_tea_entry(user_id: int):
+    data, c = (
+        supabaseClient.table(TABLE)
+        .select("*")
+        .match(
+            {
+                "user_id": user_id,
+            }
+        )
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    if c == 0:
+        return None
+    return data[1][0]

--- a/commands/bbt_count/embeds.py
+++ b/commands/bbt_count/embeds.py
@@ -151,44 +151,46 @@ def bbt_stats_embed(
         title=f"Bubble tea stats {f'for {year}' if year else 'for the past year'} {'grouped by location ' if group_by_location else ''}🧋",
         color=discord.Color.green(),
     )
-    embed.description = f"For <@{user_id}>: **{total_count} total entries**\n{average_year_string(year, total_count)}\n"
-    embed.description += "\n".join(
-        [
-            (
-                "- "
+    embed.description = f"For <@{user_id}>: **{total_count} total entries**\n{average_year_string(year, total_count)}\n\n"
+    if total_count > 0:
+        embed.description += f"{'__Total costs__' if not group_by_location else '__Costs by location__'}:\n"
+        embed.description += "\n".join(
+            [
+                (
+                    "- "
+                    + (
+                        f'**{entry.get("location")}**: '
+                        if group_by_location
+                        else ""
+                    )
+                    + cost_string(
+                        entry.get("total_price") or 0,
+                        entry.get("entry_count", 0),
+                        entry.get("currency"),
+                    )
+                    + (
+                        f" *average given rating: {entry.get('average_rating'):.3f}*"
+                        if entry.get("average_rating")
+                        else ""
+                    )
+                )
+                for entry in entries
+            ]
+        )
+        current_year = year if year else datetime.datetime.now().year
+        embed.description += "\n\n__Monthly counts__:\n"
+        embed.description += "\n".join(
+            [
+                f"**{calendar.month_name[monthly_count.get('month', 0)]}**: {monthly_count.get('entry_count')} entries ({average_string(calendar.monthrange(current_year, monthly_count.get('month', 0))[1], monthly_count.get('entry_count'))})"
                 + (
-                    f'**{entry.get("location")}**: '
-                    if group_by_location
+                    f"\n- *average given rating: {monthly_count.get('average_rating'):.3f}*"
+                    if monthly_count.get("average_rating")
                     else ""
                 )
-                + cost_string(
-                    entry.get("total_price") or 0,
-                    entry.get("entry_count", 0),
-                    entry.get("currency"),
-                )
-                + (
-                    f" *average given rating: {entry.get('average_rating'):.3f}*"
-                    if entry.get("average_rating")
-                    else ""
-                )
-            )
-            for entry in entries
-        ]
-    )
-    current_year = year if year else datetime.datetime.now().year
-    embed.description += "\n\n"
-    embed.description += "\n".join(
-        [
-            f"**{calendar.month_name[monthly_count.get('month', 0)]}**: {monthly_count.get('entry_count')} entries ({average_string(calendar.monthrange(current_year, monthly_count.get('month', 0))[1], monthly_count.get('entry_count'))})"
-            + (
-                f"\n- *average given rating: {monthly_count.get('average_rating'):.3f}*"
-                if monthly_count.get("average_rating")
-                else ""
-            )
-            for monthly_count in monthly_counts
-        ]
-    )
-    if latest:
-        embed.description += "\n\n**Latest entry**:\n"
-        embed.description += entry_string(latest, timezone)
+                for monthly_count in monthly_counts
+            ]
+        )
+        if latest:
+            embed.description += "\n\n**Latest entry**:\n"
+            embed.description += entry_string(latest, timezone)
     return embed

--- a/commands/bbt_count/embeds.py
+++ b/commands/bbt_count/embeds.py
@@ -173,4 +173,6 @@ def bbt_stats_embed(
     if latest:
         embed.description += "\n\n**Latest entry**:\n"
         embed.description += entry_string(latest, timezone)
+    else:
+        embed.description += "\n\nNo entries found for this year"
     return embed

--- a/commands/bbt_count/embeds.py
+++ b/commands/bbt_count/embeds.py
@@ -155,7 +155,7 @@ def bbt_stats_embed(
                     entry.get("total_price") or 0,
                     entry.get("entry_count", 0),
                     entry.get("currency"),
-                ) + (f" *average rating: {entry.get('average_rating'):.3f}*" if entry.get("average_rating") else '')
+                ) + (f" *average given rating: {entry.get('average_rating'):.3f}*" if entry.get("average_rating") else '')
             )
             for entry in entries
         ]

--- a/commands/bbt_count/embeds.py
+++ b/commands/bbt_count/embeds.py
@@ -155,7 +155,7 @@ def bbt_stats_embed(
                     entry.get("total_price") or 0,
                     entry.get("entry_count", 0),
                     entry.get("currency"),
-                )
+                ) + (f" *average rating: {entry.get('average_rating'):.3f}*" if entry.get("average_rating") else '')
             )
             for entry in entries
         ]

--- a/commands/bbt_count/embeds.py
+++ b/commands/bbt_count/embeds.py
@@ -151,8 +151,8 @@ def bbt_stats_embed(
     embed.description += "\n".join(
         [
             (
-                (
-                    f'- **{entry.get("location")}**: '
+                '- ' + (
+                    f'**{entry.get("location")}**: '
                     if group_by_location
                     else ""
                 )

--- a/commands/bbt_count/embeds.py
+++ b/commands/bbt_count/embeds.py
@@ -2,7 +2,6 @@ import discord
 import datetime
 import calendar
 
-
 from commands.bbt_count.helpers import (
     bubble_tea_string,
     calculate_prices,
@@ -11,7 +10,7 @@ from commands.bbt_count.helpers import (
     cost_string_prices,
     cost_string,
     average_year_string,
-    average_string,
+    average_month_string,
 )
 
 
@@ -181,9 +180,9 @@ def bbt_stats_embed(
         embed.description += "\n\n__Monthly counts__:\n"
         embed.description += "\n".join(
             [
-                f"**{calendar.month_name[monthly_count.get('month', 0)]}**: {monthly_count.get('entry_count')} entries ({average_string(calendar.monthrange(current_year, monthly_count.get('month', 0))[1], monthly_count.get('entry_count'))})"
+                f"**{calendar.month_name[monthly_count.get('month', 0)]}**: {monthly_count.get('entry_count')} entries ({average_month_string(current_year, monthly_count.get('month', 0), monthly_count.get('entry_count'))})"
                 + (
-                    f"\n- *average given rating: {monthly_count.get('average_rating'):.3f}*"
+                    f"\n- */average given rating: {monthly_count.get('average_rating'):.3f}*"
                     if monthly_count.get("average_rating")
                     else ""
                 )

--- a/commands/bbt_count/embeds.py
+++ b/commands/bbt_count/embeds.py
@@ -135,7 +135,12 @@ def bbt_list_grouped_embed(
 
 
 def bbt_stats_embed(
-    user_id: int, entries: list[dict], year: int, group_by_location: bool
+    user_id: int,
+    entries: list[dict],
+    year: int,
+    group_by_location: bool,
+    latest: dict,
+    timezone: datetime.tzinfo,
 ):
     total_count = sum([entry.get("entry_count", 0) for entry in entries])
     embed = discord.Embed(
@@ -155,9 +160,17 @@ def bbt_stats_embed(
                     entry.get("total_price") or 0,
                     entry.get("entry_count", 0),
                     entry.get("currency"),
-                ) + (f" *average given rating: {entry.get('average_rating'):.3f}*" if entry.get("average_rating") else '')
+                )
+                + (
+                    f" *average given rating: {entry.get('average_rating'):.3f}*"
+                    if entry.get("average_rating")
+                    else ""
+                )
             )
             for entry in entries
         ]
     )
+    if latest:
+        embed.description += "\n\n**Latest entry**:\n"
+        embed.description += entry_string(latest, timezone)
     return embed

--- a/commands/bbt_count/helpers.py
+++ b/commands/bbt_count/helpers.py
@@ -103,5 +103,21 @@ def entry_string(entry: dict, timezone: datetime.tzinfo):
     return entry_string.strip()
 
 
-def average_string(year: int, entry_count: int):
-    return f"Average of 1 🧋 every {(((datetime.date.today() if not year or year == datetime.date.today().year else datetime.date(year, 12, 31)) - datetime.date(year or datetime.date.today().year, 1, 1)).days)/entry_count:.3f} days"
+def average_string(days: int, entry_count: int):
+    return (
+        f"Average of 1 🧋 every {days/entry_count:.3f} days"
+        if days and entry_count
+        else "Average of 0 🧋"
+    )
+
+
+def average_year_string(year: int, entry_count: int):
+    days = (
+        (
+            datetime.date.today()
+            if not year or year == datetime.date.today().year
+            else datetime.date(year, 12, 31)
+        )
+        - datetime.date(year or datetime.date.today().year, 1, 1)
+    ).days
+    return average_string(days, entry_count)

--- a/commands/bbt_count/helpers.py
+++ b/commands/bbt_count/helpers.py
@@ -1,6 +1,7 @@
 from babel import numbers, Locale
 import datetime
 import numpy as np
+import calendar
 
 locale = Locale("en", "US")
 
@@ -103,9 +104,9 @@ def entry_string(entry: dict, timezone: datetime.tzinfo):
     return entry_string.strip()
 
 
-def average_string(days: int, entry_count: int):
+def average_string(days: int, entry_count: int, is_current: bool):
     return (
-        f"Average of 1 🧋 every {days/entry_count:.3f} days"
+        f"Average of 1 🧋 every {days/entry_count:.3f} days {'*so far*' if is_current else ''}".strip()
         if days and entry_count
         else "Average of 0 🧋"
     )
@@ -119,5 +120,25 @@ def average_year_string(year: int, entry_count: int):
             else datetime.date(year, 12, 31)
         )
         - datetime.date(year or datetime.date.today().year, 1, 1)
-    ).days
-    return average_string(days, entry_count)
+    ).days + 1
+    is_current = not year or year == datetime.date.today().year
+    return average_string(days, entry_count, is_current)
+
+
+def average_month_string(year: int, month: int, entry_count: int):
+    ## check if the year and month are the current year and month, and if so, use the days from the beginning to the current date
+    days = (
+        (
+            datetime.date.today()
+            if (not year or year == datetime.date.today().year)
+            and month == datetime.date.today().month
+            else datetime.date(
+                year, month, calendar.monthrange(year, month)[1]
+            )
+        )
+        - datetime.date(year or datetime.date.today().year, month, 1)
+    ).days + 1
+    is_current = (
+        not year or year == datetime.date.today().year
+    ) and month == datetime.date.today().month
+    return average_string(days, entry_count, is_current)

--- a/commands/bbt_count/helpers.py
+++ b/commands/bbt_count/helpers.py
@@ -83,9 +83,13 @@ def calculate_prices(entries: list[dict], group_by: str):
     return prices
 
 
-def cost_string(prices: list[int], currency: str):
+def cost_string_prices(prices: list[int], currency: str):
     p = np.array(prices)
-    return f"{numbers.format_currency(p.sum(), currency, locale='en_US')} ({p.size}, avg {numbers.format_currency(p[p.nonzero()].mean() if p.sum() else 0, currency, locale='en_US')}/🧋)"
+    return cost_string(p.sum(), p.size, currency)
+
+
+def cost_string(total_price: float, count: int, currency: str):
+    return f"{numbers.format_currency(total_price, currency, locale='en_US')} ({count}, avg {numbers.format_currency(total_price/count if total_price and count else 0, currency, locale='en_US')}/🧋)"
 
 
 def entry_string(entry: dict, timezone: datetime.tzinfo):
@@ -97,3 +101,7 @@ def entry_string(entry: dict, timezone: datetime.tzinfo):
         f" {'notes: ' + entry.get('notes') if entry.get('notes') else ''}"
     )
     return entry_string.strip()
+
+
+def average_string(year: int, entry_count: int):
+    return f"Average of 1 🧋 every {(((datetime.date.today() if not year or year == datetime.date.today().year else datetime.date(year, 12, 31)) - datetime.date(year or datetime.date.today().year, 1, 1)).days)/entry_count:.3f} days"

--- a/tests/test_bbt_count/test_helpers.py
+++ b/tests/test_bbt_count/test_helpers.py
@@ -2,7 +2,7 @@ from commands.bbt_count.helpers import (
     bubble_tea_string,
     price_string,
     calculate_prices,
-    cost_string,
+    cost_string_prices,
     entry_string,
 )
 
@@ -102,7 +102,7 @@ def test_cost_string():
     prices = [3.5, 4.0, 3.0, 0]
     currency = "USD"
     expected_result = "$10.50 (4, avg $3.50/🧋)"
-    assert cost_string(prices, currency) == expected_result
+    assert cost_string_prices(prices, currency) == expected_result
 
 
 def test_entry_string():


### PR DESCRIPTION
# Bubble tea stats

Shows the bubble tea stats of either for the past year or for a given year. Similar to `bbt_count list` but without listing all the entries.

![image](https://github.com/placeTW/discord-bot/assets/16857036/c8ce7307-3789-4ed3-9ecf-ffb2181cd078)

Optionally group by location:
![image](https://github.com/placeTW/discord-bot/assets/16857036/2f1b5e7e-6857-47ff-b722-acb804e3f096)
