### PR TITLE
Add JP, Baltic meows, fix original regex

### DIFF
--- a/commands/meow/consts.py
+++ b/commands/meow/consts.py
@@ -7,19 +7,41 @@ POSSIBLE_MEOW_REACTS = [
     '<a:catArrive:1161441364869918881>',
     '<:Capoo:1139357657698938991>'
 ]
+
+JP_MEOWs = [
+    "ニャー",
+    "にゃー",
+]
+
+BALTIC_MEOWs = [
+    # Estonian
+    "mjäu",
+    # Latvian
+    "mjau",
+    # Lithuanian
+    "miau",
+]
+BALTIC_MEOWs = [rf"\b{meow}\b" for meow in BALTIC_MEOWs] # to match whole words only
+
+CZECH_MEOWs = [
+    "mňau",
+]
+CZECH_MEOWs = [rf"\b{meow}\b" for meow in CZECH_MEOWs] # to match whole words only
+
 POSSIBLE_MEOW_MESSAGES = [
     MEOW,
     TRADITIONAL_CAT,
     'meow',
     '瞄',
     '錨',
-    'ㄇㄧㄠ'
-] + POSSIBLE_MEOW_REACTS
+    'ㄇㄧㄠ',
+    
+] + POSSIBLE_MEOW_REACTS + JP_MEOWs
 
 CHISOBCAT = '<:ChisobCat:1157361078452375582>'
 SHIBELOL = '<:dogekek:1132350110148333718>'
 
 MEOW_REGEX = compile(
-    rf"\b(?:{'|'.join(POSSIBLE_MEOW_MESSAGES)})",
+    rf"(?:{'|'.join(POSSIBLE_MEOW_MESSAGES)})",
     flags=IGNORECASE | UNICODE,
 )


### PR DESCRIPTION
# 喵
* Added JP meows
* Added Baltic meows
* Added `\b` to force whole word match
* Fixed original regex (removed leading `\b`)

Other possible future changes:
* New meow reacts
* Words for "cat" (not just "meow") in other languages 
* Tests for meow

