### PR TITLE
Taigi quiz: make choices the same length

### DIFF
--- a/commands/taiwanese/quiz.py
+++ b/commands/taiwanese/quiz.py
@@ -4,7 +4,7 @@ import sys, re
 from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent.parent)) # I hate python imports
 from modules.quiz.multiple_choice import MultipleChoiceView, QuizChoice
-from .read_embree_csv import TW_EMBREE_CSV
+from .read_embree_csv import TW_EMBREE_CSV, NUM_WORDS_COL
 
 DISCORD_MAX_LABEL_LENGTH = 80
 
@@ -35,10 +35,14 @@ def register_quiz_subcommand(
         num_rows: Choice[int] = None,
         is_private: bool = False,
     ):
-        # get the number of rows to sample
-        num_rows = num_rows.value if num_rows else 4
+        # select a random value from the NUM_WORDS_COL column
+        word_length = TW_EMBREE_CSV[NUM_WORDS_COL].sample().iloc[0]
+        # filter the dataframe based on the word length
+        tw_csv_subset = TW_EMBREE_CSV[TW_EMBREE_CSV[NUM_WORDS_COL] == word_length]
+        # get the number of rows to sample, which is the minimum of 4 and the length of the subset
+        num_rows = min(num_rows.value if num_rows else 4, len(tw_csv_subset))
         # get num_rows random rows and choose one as the correct answer
-        random_rows = TW_EMBREE_CSV.sample(num_rows)
+        random_rows = tw_csv_subset.sample(num_rows)
         # convert to TaigiQuizChoice objects
         correct_row_index = random_rows.sample().index[0]
         choices = [

--- a/commands/taiwanese/quiz.py
+++ b/commands/taiwanese/quiz.py
@@ -1,6 +1,6 @@
 import discord
 from discord.app_commands import Choice
-import sys, re
+import sys, re, random
 from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent.parent)) # I hate python imports
 from modules.quiz.multiple_choice import MultipleChoiceView, QuizChoice
@@ -49,6 +49,8 @@ def register_quiz_subcommand(
             TaigiQuizChoice(row["PojUnicode"], correct_row_index == i, row["EngBun"], row["HoaBun"])
             for i, row in random_rows.iterrows()
         ]
+        # shuffle the choices
+        random.shuffle(choices)
         # create the view
         view = MultipleChoiceView(choices)
         # send the message

--- a/commands/taiwanese/read_embree_csv.py
+++ b/commands/taiwanese/read_embree_csv.py
@@ -25,6 +25,7 @@ The + means to keep the field, - means to discard the field.
 INDEX_COL = 0
 # to save memory, only keep the columns we need
 COLS_TO_KEEP = ("PojUnicode", "PojInput", "Abbreviation", "NounClassifier", "HoaBun", "EngBun")
+NUM_WORDS_COL = "num_words"
 
 def read_embree_csv_raw(
     filepath: Path,
@@ -39,7 +40,7 @@ def read_embree_csv_raw(
 
 def add_pd_columns(tw_csv: pd.DataFrame) -> pd.DataFrame:
     # add the length of each word
-    tw_csv["num_words"] = tw_csv["PojUnicode"].apply(lambda x: x.split("/")[0].count("-")+1)
+    tw_csv[NUM_WORDS_COL] = tw_csv["PojUnicode"].apply(lambda x: x.split("/")[0].count("-")+1)
     return tw_csv
 
 TW_EMBREE_CSV_PATH = Path(__file__).parent / "ChhoeTaigi_EmbreeTaiengSutian.csv"

--- a/commands/taiwanese/read_embree_csv.py
+++ b/commands/taiwanese/read_embree_csv.py
@@ -37,5 +37,11 @@ def read_embree_csv_raw(
     df = df.fillna("") # replace all NaN with empty string
     return df
 
+def add_pd_columns(tw_csv: pd.DataFrame) -> pd.DataFrame:
+    # add the length of each word
+    tw_csv["num_words"] = tw_csv["PojUnicode"].apply(lambda x: x.split("/")[0].count("-")+1)
+    return tw_csv
+
 TW_EMBREE_CSV_PATH = Path(__file__).parent / "ChhoeTaigi_EmbreeTaiengSutian.csv"
 TW_EMBREE_CSV = read_embree_csv_raw(TW_EMBREE_CSV_PATH)
+TW_EMBREE_CSV = add_pd_columns(TW_EMBREE_CSV)


### PR DESCRIPTION
## Problem

You can generally guess the Taiwanese by comparing the number of characters in Hoabun and Taiwanese. Note that not all Hoabun have the same length as Taiwanese but it's common enough to make guessing trivial.

## Solution

A `num_words` is added to the Taiwanese dataframe on startup, which is used to filter rows.

Choices are now only same length to make guessing based on Hoabun (Mandarin) harder.
This will sometimes lead to, in exceptionally rare cases, having only one choice (which is the correct one), but we could leave it like that.

## Other stuff
Added shuffling since I apparently forgot 