### PR TITLE
Add more languages to unit tests

### DIFF
--- a/commands/taiwanese/read_embree_csv.py
+++ b/commands/taiwanese/read_embree_csv.py
@@ -36,6 +36,8 @@ def read_embree_csv_raw(
     if cols_to_keep:
         df = df[list(cols_to_keep)]
     df = df.fillna("") # replace all NaN with empty string
+    # drop all rows where PojUnicode is empty
+    df = df[df["PojUnicode"] != ""]
     return df
 
 def _count_taigi_words(poj: str) -> int:

--- a/tests/test_fetch_entry.py
+++ b/tests/test_fetch_entry.py
@@ -1,14 +1,8 @@
 import commands.fetch_entry.fetch_entry_main as fetch
 import pytest
 
+LANGS_TO_TEST = ["cz", "en", "et", "fr", "lt", "lv", "ua", "zh"]
 
-# @pytest.mark.parametrize(
-#     "entry,lang,field",
-#     [
-#         ("capoo", "en", "title"),
-#         ("taipei_101", "lt", "title"),
-#     ],
-# )
 @pytest.mark.parametrize("entry", ["capoo"])
 @pytest.mark.parametrize("lang", ["en", "lt", "et"])
 @pytest.mark.parametrize("field", ["title", "blurb", "desc", None])
@@ -26,7 +20,7 @@ async def test__fetch_entry_with_json_valid_input_returns_str(
 
 
 @pytest.mark.parametrize("entry", ["capoo"])
-@pytest.mark.parametrize("lang", ["en", "lt", "et"])
+@pytest.mark.parametrize("lang", LANGS_TO_TEST)
 async def test__fetch_entry_with_json_valid_input_links_returns_list(
     entry, lang
 ):

--- a/tests/test_taigi.py
+++ b/tests/test_taigi.py
@@ -7,8 +7,8 @@ def test_num_words_col():
     assert NUM_WORDS_COL in TW_EMBREE_CSV.columns
     # assert it contains only integers
     assert TW_EMBREE_CSV[NUM_WORDS_COL].dtype == int
-    # assert that there are no negative values
-    assert (TW_EMBREE_CSV[NUM_WORDS_COL] >= 0).all()
+    # assert that there all values are > 0
+    assert (TW_EMBREE_CSV[NUM_WORDS_COL] > 0).all()
 
 @pytest.mark.parametrize(
     "poj,expected", 


### PR DESCRIPTION
Instead of testing just EN, LT and ET, test `["cz", "en", "et", "fr", "lt", "lv", "ua", "zh"]`

Result: some art pieces still need to be fixed/added