### PR TITLE
Main.py overhaul and deployment tests

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -35,9 +35,14 @@ jobs:
           key: venv-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies using Poetry 
         run: poetry install
-      - name: Test with pytest  
+      - name: Run unit tests with pytest
         run: |  
-            poetry run python -m pytest tests/ -s --durations=5
+            poetry run python -m pytest tests/ -s --durations=5 -m "not deployment"
+      - name: Run deployment tests with pytest
+        run: |  
+            poetry run python -m pytest tests/ -s --durations=5 -m deployment
+            
+
     #   - name: Generate Coverage Report  
     #     run: |  
     #       coverage report -m

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run unit tests with pytest
         run: |  
             poetry run python -m pytest tests/ -m 'not deployment' --durations=5 
+      - name: Debugging, see markers
+        run: |  
+            poetry run python -m pytest --markers
       - name: Run deployment tests with pytest
         run: |  
             poetry run python -m pytest tests/ -m deployment --durations=0 

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Run unit tests with pytest
         run: |  
             poetry run python -m pytest tests/ -m 'not deployment' --durations=5 
-      - name: Debugging, see markers
-        run: |  
-            poetry run python -m pytest --markers
       - name: Run deployment tests with pytest
         run: |  
             poetry run python -m pytest tests/ -m deployment --durations=0 

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -37,10 +37,10 @@ jobs:
         run: poetry install
       - name: Run unit tests with pytest
         run: |  
-            poetry run python -m pytest tests/ -s --durations=5 -m "not deployment"
+            poetry run python -m pytest tests/ -m 'not deployment' --durations=5 
       - name: Run deployment tests with pytest
         run: |  
-            poetry run python -m pytest tests/ -s --durations=5 -m deployment
+            poetry run python -m pytest tests/ -m deployment --durations=0 
             
 
     #   - name: Generate Coverage Report  

--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ class BotInitialiser:
                     "server_name": guild.name,
                 }
             ).execute()
-            register_commands(self.tree, self.client, [guild])
+            self.register_commands(self.tree, self.client, [guild])
             await self.tree.sync(guild=guild)
     
 

--- a/main.py
+++ b/main.py
@@ -43,124 +43,132 @@ import platform
 
 # load environment vars (from .env)
 load_dotenv()
-is_prod = len(sys.argv) > 1 and sys.argv[1] == "prod"
-TOKEN = os.getenv("DISCORD_TOKEN_DEV" if not is_prod else "DISCORD_TOKEN")
+IS_PROD = len(sys.argv) > 1 and sys.argv[1] == "prod"
+TOKEN = os.getenv("DISCORD_TOKEN_DEV" if not IS_PROD else "DISCORD_TOKEN")
 
-deployment_date = datetime.datetime.now()
-client = bot.get_bot(is_prod)
-# CommandTree is where all our defined commands are stored
-tree = discord.app_commands.CommandTree(client)
-placetw_guild = discord.Object(
-    id=os.getenv("PLACETW_SERVER_ID")
-)  # basically refers to this server
+DEPLOYMENT_DATE = datetime.datetime.now()
 
-
-@tree.command(
-    name="deployment-info",
-    description="Returns information about the bot deployment",
-    guild=placetw_guild,
-)
-async def deployment_info(interaction: discord.Interaction):
-    branch_name = Repo().active_branch.name
-    msg = f"""
-PlaceTW discord bot ({'prod' if is_prod else 'dev'} deployment)
-Branch deployed: `{branch_name}`
-Python version: `{platform.python_version()}`
-Operating system: `{platform.platform()}`
-Deployed on `{deployment_date.ctime()} ({deployment_date.astimezone().tzinfo})`
-https://github.com/placeTW/discord-bot{f'/tree/{branch_name}' if branch_name != 'main' else ''}
-    """
-    await interaction.response.send_message(msg)
-
-
-# * register commands the just the placetw server
-edit_entry_cmd.register_commands(tree, placetw_guild, client)
-restart.register_commands(tree, placetw_guild)
-activity.register_commands(tree, placetw_guild, client)
-tocfl.register_commands(tree, placetw_guild, client)
-taiwanese_entry.register_commands(tree, placetw_guild, client)
-
-# * register commands to the other servers
-guilds = [
-    discord.Object(id=int(server_id))
-    for server_id in client.guilds_dict.keys()
-]
-
-def register_commands(tree, client, guilds):
-    # * Register commands to all servers that the bot is in
-    bbt_count.register_commands(tree, client, guilds)
-    fetch_entry_cmd.register_commands(tree, guilds)
-    fetch_entry_ui.register_commands(tree, guilds)
-    one_o_one.register_commands(tree, guilds)
-    hgs.register_commands(tree, guilds)
-    random_shiba.register_commands(tree, guilds)
-    random_capoo.register_commands(tree, guilds)
-    fucking.register_commands(tree, guilds)
-    boba.register_commands(tree, guilds)
-    basic_commands.register_commands(tree, guilds)
-    config_commands.register_commands(tree, client, guilds)
-    stats.register_commands(tree, client, guilds)
-    pat.register_commands(tree, client, guilds)
-    formosa_stickers.register_commands(tree, guilds)
-
-
-register_commands(tree, client, guilds)
-
-
-# confessions needs the dictionary for the confession channel id
-confession.register_commands(tree, client)
-
-
-# sync the slash commands servers
-@client.event
-async def on_ready():
-    for guild_id in client.guilds_dict.keys():
-        guild = discord.Object(id=guild_id)
-        await tree.sync(guild=guild)
-    # Enable logging
-    logging.init(client, deployment_date)
-    print("Bot is ready.")
-
-
-# when someone sends any message
-@client.event
-async def on_message(message: discord.Message):
-    message_reacts_enabled = True
-    try:
-        message_reacts_enabled = client.guilds_dict[message.guild.id][
-            "message_reacts_enabled"
+class BotInitialiser:
+    def __init__(self):
+        self.client = bot.get_bot(IS_PROD)
+        self.guilds = [
+            discord.Object(id=int(server_id))
+            for server_id in self.client.guilds_dict.keys()
         ]
-    except:
-        # default true
-        pass
+        # CommandTree is where all our defined commands are stored
+        self.tree = discord.app_commands.CommandTree(self.client)
+        self.placetw_guild = discord.Object(
+            id=os.getenv("PLACETW_SERVER_ID")
+        )  # basically refers to this server
+        self.register_commands()
 
-    # don't respond to bot's own posts or if message reacts are disabled
-    if message.author == client.user or not message_reacts_enabled:
-        return
-
-    events = []
-
-    if client.user.mentioned_in(message):  # if bot is pinged in message
-        await mention_responses.reply_with_random_response(message)
-        events.append("pinged")
-
-    react_events = await handle_message_react(message)
-    events += react_events
-
-    if len(events) > 0:
-        await logging.log_message_event(message, events)
+    def register_commands(self):
+        self.register_placetw_commands()
+        self.register_commands_in_all_servers()
+        self.register_event_callbacks()
 
 
-@client.event
-async def on_guild_join(guild):
-    supabaseClient.table("server_config").insert(
-        {
-            "guild_id": str(guild.id),
-            "server_name": guild.name,
-        }
-    ).execute()
-    register_commands(tree, client, [guild])
-    await tree.sync(guild=guild)
+    def register_placetw_commands(self):
+        @self.tree.command(
+            name="deployment-info",
+            description="Returns information about the bot deployment",
+            guild=self.placetw_guild,
+        )
+        async def deployment_info(interaction: discord.Interaction):
+            branch_name = Repo().active_branch.name
+            msg_list = [
+                f"PlaceTW discord bot ({'prod' if IS_PROD else 'dev'} deployment)",
+                f"Branch deployed: `{branch_name}`",
+                f"Python version: `{platform.python_version()}`",
+                f"Operating system: `{platform.platform()}`",
+                f"Deployed on `{DEPLOYMENT_DATE.ctime()} ({DEPLOYMENT_DATE.astimezone().tzinfo})`",
+                f"https://github.com/placeTW/discord-bot{f'/tree/{branch_name}' if branch_name != 'main' else ''}",
+            ]
+            msg = "\n".join(msg_list)
+            await interaction.response.send_message(msg)
 
 
-client.run(TOKEN)
+        # * register commands the just the placetw server
+        edit_entry_cmd.register_commands(self.tree, self.placetw_guild, self.client)
+        restart.register_commands(self.tree, self.placetw_guild)
+        activity.register_commands(self.tree, self.placetw_guild, self.client)
+        tocfl.register_commands(self.tree, self.placetw_guild, self.client)
+        taiwanese_entry.register_commands(self.tree, self.placetw_guild, self.client)
+
+    def register_commands_in_all_servers(self):
+        # * register commands to the other servers
+        bbt_count.register_commands(self.tree, self.client, self.guilds)
+        fetch_entry_cmd.register_commands(self.tree, self.guilds)
+        fetch_entry_ui.register_commands(self.tree, self.guilds)
+        one_o_one.register_commands(self.tree, self.guilds)
+        hgs.register_commands(self.tree, self.guilds)
+        random_shiba.register_commands(self.tree, self.guilds)
+        random_capoo.register_commands(self.tree, self.guilds)
+        fucking.register_commands(self.tree, self.guilds)
+        boba.register_commands(self.tree, self.guilds)
+        basic_commands.register_commands(self.tree, self.guilds)
+        config_commands.register_commands(self.tree, self.client, self.guilds)
+        stats.register_commands(self.tree, self.client, self.guilds)
+        pat.register_commands(self.tree, self.client, self.guilds)
+        formosa_stickers.register_commands(self.tree, self.guilds)
+        confession.register_commands(self.tree, self.client)
+
+    def register_event_callbacks(self):
+        # sync the slash commands servers when the bot is ready
+        @self.client.event
+        async def on_ready():
+            for guild_id in self.client.guilds_dict.keys():
+                guild = discord.Object(id=guild_id)
+                await self.tree.sync(guild=guild)
+            # Enable logging
+            logging.init(self.client, DEPLOYMENT_DATE)
+            print("Bot is ready.")
+
+
+        # when someone sends any message
+        @self.client.event
+        async def on_message(message: discord.Message):
+            message_reacts_enabled = True
+            try:
+                message_reacts_enabled = self.client.guilds_dict[message.guild.id][
+                    "message_reacts_enabled"
+                ]
+            except:
+                # default true
+                pass
+
+            # don't respond to bot's own posts or if message reacts are disabled
+            if message.author == self.client.user or not message_reacts_enabled:
+                return
+
+            events = []
+
+            if self.client.user.mentioned_in(message):  # if bot is pinged in message
+                await mention_responses.reply_with_random_response(message)
+                events.append("pinged")
+
+            react_events = await handle_message_react(message)
+            events += react_events
+
+            if len(events) > 0:
+                await logging.log_message_event(message, events)
+
+
+        @self.client.event
+        async def on_guild_join(guild):
+            supabaseClient.table("server_config").insert(
+                {
+                    "guild_id": str(guild.id),
+                    "server_name": guild.name,
+                }
+            ).execute()
+            register_commands(self.tree, self.client, [guild])
+            await self.tree.sync(guild=guild)
+    
+
+    def run(self):
+        self.client.run(TOKEN)
+
+if __name__ == "__main__":
+    discord_bot = BotInitialiser()
+    discord_bot.run()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 pythonpath = "./commands/"
 asyncio_mode=auto
+markers = 
+    deployment: mark a test as a deployment test.

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,5 +1,6 @@
 import pytest
 from main import BotInitialiser
+import supabase
 
 @pytest.mark.deployment
 def test_BotInitialiser(monkeypatch):
@@ -11,6 +12,10 @@ def test_BotInitialiser(monkeypatch):
     def mock_run(*args, **kwargs):
         pass
     monkeypatch.setattr(BotInitialiser, "run", mock_run)
+    # patch supabase.create_client to do nothing
+    def mock_create_client(*args, **kwargs):
+        pass
+    monkeypatch.setattr(supabase, "create_client", mock_create_client)
 
     # create a BotInitialiser object
     bot = BotInitialiser()

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -6,6 +6,9 @@ import github
 def test_BotInitialiser(monkeypatch):
     # | Note: the order of the imports is important since some modules depend on others being patched first
 
+    # * PATCH ENVIRONMENT VARIABLES
+    monkeypatch.setenv("PLACETW_SERVER_ID", "999") # set the environment variable for the placetw server id
+
     # * PATCH SUPABASE MODULE
     # patch the create_client command to do nothing
     def mock_create_client(url: str, private_key: str):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,24 @@
+import pytest
+from main import BotInitialiser
+
+@pytest.mark.deployment
+def test_BotInitialiser(monkeypatch):
+    # patch the register_commands command to do nothing
+    def mock_register_commands(*args, **kwargs):
+        pass
+    monkeypatch.setattr(BotInitialiser, "register_commands", mock_register_commands)
+    # patch the run command to do nothing (just in case)
+    def mock_run(*args, **kwargs):
+        pass
+    monkeypatch.setattr(BotInitialiser, "run", mock_run)
+
+    # create a BotInitialiser object
+    bot = BotInitialiser()
+    # assert that the BotInitialiser object is created
+    assert isinstance(bot, BotInitialiser)
+    # assert that self.client, self.guilds, self.tree are created
+    assert hasattr(bot, "client")
+    assert hasattr(bot, "guilds")
+    assert hasattr(bot, "tree")
+    # assert that self.placetw_guild is created
+    assert hasattr(bot, "placetw_guild")


### PR DESCRIPTION
* Rewrote `main.py` as a class for modularity and to allow monkey patching
* Created deployment test:
  * Monkeypatched away several functions that `main.py` needs but requires internet access
  * **Tests that the bot can run** with minimal external API calls, e.g., the `main.py` has no import or syntax errors on launch
* Marked deployment test to differentiate it from unit tests
* Changed actions file to run unit and deployment tests separately for clarity