### PR TITLE
add param to json() because github uses text/plain for some reason

### DIFF
--- a/commands/edit_entry/edit_entry_cmd.py
+++ b/commands/edit_entry/edit_entry_cmd.py
@@ -37,7 +37,7 @@ def register_commands(tree, this_guild: discord.Object, client: discord.Client):
         selected_entry_name = entry.name  # entry always exists
         selected_field = field.value  # field is mandatory here
         initial_value = await _fetch_entry_with_json(
-            interaction, selected_entry_id, selected_lang, selected_field, fromI18n=True
+            interaction, selected_entry_id, selected_lang, selected_field, fromI18n=True, expected_content_type=None
         )
         form = submit_entry_modal.SubmitEntryModal(
             client,

--- a/commands/fetch_entry/fetch_entry_main.py
+++ b/commands/fetch_entry/fetch_entry_main.py
@@ -13,7 +13,7 @@ from commands.entry_consts.consts import (
 )
 
 
-async def get_json(how="url", json_url="") -> dict:
+async def get_json(how="url", json_url="", expected_content_type='application/json') -> dict:
     """A multi-purpose function to fetch json.
     Right now, the only source is a json url, but in case
     things cahnge in the future, we can just modify this function.
@@ -27,12 +27,12 @@ async def get_json(how="url", json_url="") -> dict:
     """
     assert how in ("url",)
     if how == "url":
-        result = await async_utils._async_get_json(json_url)
+        result = await async_utils._async_get_json(json_url, expected_content_type)
     return result
 
 
 async def _fetch_entry_with_json(
-    interaction: discord.Interaction, entry: str, lang: str, field: str = None, fromI18n: bool = False
+    interaction: discord.Interaction, entry: str, lang: str, field: str = None, fromI18n: bool = False, expected_content_type='application/json'
 ):
     """Function to fetch entry based on json entries.
     This is called by both the cmd and ui version of fectch_entry,
@@ -52,6 +52,7 @@ async def _fetch_entry_with_json(
     result_json = await get_json(
         how="url",
         json_url=link_to_fetch,
+        expected_content_type=expected_content_type
     )
     # * if some error happens, notify user and stop
     if result_json is None:

--- a/modules/async_utils.py
+++ b/modules/async_utils.py
@@ -1,7 +1,7 @@
 import aiohttp
 
 
-async def _async_get_json(url: str) -> str:
+async def _async_get_json(url: str, expected_content_type='application/json') -> str:
     """An async version of getting a JSON file.
     This is because discord doesn't like it when
     you use blocking IO (non async) for HTTP requests,
@@ -10,13 +10,14 @@ async def _async_get_json(url: str) -> str:
 
     Args:
         url (str): _description_
+        expected_content_type: passed to response.json(). Use None to disable content type checking.
 
     Returns:
         str: _description_
     """
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as response:
-            return await response.json()
+            return await response.json(content_type=expected_content_type)
 
 async def _async_get_html(url: str) -> str:
     """An async version of getting a HTML file.


### PR DESCRIPTION
Github's raw content uses `text/plain` for some reason, even if it's a json file; so we use `None` to suppress MIME content validation by aiohttp.